### PR TITLE
Refine error handling for Supabase operations

### DIFF
--- a/src/components/OpenIdeaForm.tsx
+++ b/src/components/OpenIdeaForm.tsx
@@ -78,10 +78,17 @@ export function OpenIdeaForm({ onSuccess }: OpenIdeaFormProps) {
       });
 
       onSuccess?.(idea.id);
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to submit idea', error);
+      let description = 'Failed to submit idea. Please try again.';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to submit idea. Please try again.",
+        description,
         variant: "destructive",
       });
     } finally {

--- a/src/components/composer/BusinessInsightComposer.tsx
+++ b/src/components/composer/BusinessInsightComposer.tsx
@@ -105,11 +105,17 @@ export function BusinessInsightComposer({ open, onOpenChange, onSuccess }: Busin
 
       onOpenChange(false);
       onSuccess?.();
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error posting business insight:', error);
+      let description = 'Failed to post business insight';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to post business insight",
+        description,
         variant: "destructive",
       });
     } finally {

--- a/src/components/forms/SecureContactForm.tsx
+++ b/src/components/forms/SecureContactForm.tsx
@@ -72,14 +72,24 @@ export function SecureContactForm({ className, onSuccess }: SecureContactFormPro
       reset();
       onSuccess?.();
 
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Contact form error:', error);
-      
-      let errorMessage = 'Failed to send message. Please try again.';
-      
-      if (error.message?.includes('RATE_LIMIT_EXCEEDED')) {
+
+      const message =
+        error instanceof Error
+          ? error.message
+          : error &&
+              typeof error === 'object' &&
+              'message' in error &&
+              typeof (error as { message?: unknown }).message === 'string'
+            ? (error as { message: string }).message
+            : null;
+
+      let errorMessage = message ?? 'Failed to send message. Please try again.';
+
+      if (message?.includes('RATE_LIMIT_EXCEEDED')) {
         errorMessage = 'Too many requests. Please wait before sending another message.';
-      } else if (error.message?.includes('VALIDATION_ERROR')) {
+      } else if (message?.includes('VALIDATION_ERROR')) {
         errorMessage = 'Please check your input and try again.';
       }
 

--- a/src/components/landing/ComposerSection.tsx
+++ b/src/components/landing/ComposerSection.tsx
@@ -127,11 +127,17 @@ export function ComposerSection({ isVisible }: ComposerSectionProps) {
         throw new Error(data?.error || 'Unknown error');
       }
 
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error submitting idea:', error);
+      let description = 'Failed to submit idea. Please try again.';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: error.message || 'Failed to submit idea. Please try again.',
+        description,
         variant: 'destructive',
       });
     } finally {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -31,10 +31,17 @@ export function Header() {
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
       navigate('/');
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to sign out', error);
+      let description = 'Failed to sign out';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to sign out",
+        description,
         variant: "destructive",
       });
     }

--- a/src/components/navigation/GlobalNavigationMenu.tsx
+++ b/src/components/navigation/GlobalNavigationMenu.tsx
@@ -33,10 +33,17 @@ export function GlobalNavigationMenu() {
       const { error } = await supabase.auth.signOut();
       if (error) throw error;
       navigate('/');
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to sign out', error);
+      let description = 'Failed to sign out';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to sign out",
+        description,
         variant: "destructive",
       });
     }

--- a/src/components/profile/ProfileForm.tsx
+++ b/src/components/profile/ProfileForm.tsx
@@ -89,10 +89,17 @@ export function ProfileForm() {
       });
       setInviteToken("");
       await refetchRoles();
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error("Failed to accept invite", error);
+      let description = "Failed to accept invite. Please check your token.";
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === "object" && "message" in error && typeof (error as { message?: unknown }).message === "string") {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to accept invite. Please check your token.",
+        description,
         variant: "destructive",
       });
     } finally {

--- a/src/hooks/useBusinessInvitations.ts
+++ b/src/hooks/useBusinessInvitations.ts
@@ -47,11 +47,17 @@ export function useBusinessInvitations() {
 
       if (error) throw error;
       setInvitations(data as BusinessInvitation[] || []);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching sent invitations:', error);
+      let description = 'Failed to fetch sent invitations';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: 'Failed to fetch sent invitations',
+        description,
         variant: 'destructive',
       });
     } finally {
@@ -78,11 +84,17 @@ export function useBusinessInvitations() {
 
       if (error) throw error;
       setReceivedInvitations(data as BusinessInvitation[] || []);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching received invitations:', error);
+      let description = 'Failed to fetch received invitations';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: 'Failed to fetch received invitations',
+        description,
         variant: 'destructive',
       });
     } finally {
@@ -118,11 +130,17 @@ export function useBusinessInvitations() {
       }
 
       return row; // { token, expires_at }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating invitation:', error);
+      let description = 'Failed to send invitation';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: error.message || 'Failed to send invitation',
+        description,
         variant: 'destructive',
       });
       throw error;
@@ -149,11 +167,17 @@ export function useBusinessInvitations() {
       setReceivedInvitations(prev => prev.filter(inv => inv.token !== token));
       await fetchSentInvitations();
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error accepting invitation:', error);
+      let description = 'Failed to accept invitation';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: error.message || 'Failed to accept invitation',
+        description,
         variant: 'destructive',
       });
       return false;
@@ -187,11 +211,17 @@ export function useBusinessInvitations() {
         description: 'The invitation was closed.',
       });
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error rejecting invitation:', error);
+      let description = 'Failed to reject invitation';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: 'Error',
-        description: 'Failed to reject invitation',
+        description,
         variant: 'destructive',
       });
       return false;

--- a/src/hooks/useBusinessProfile.ts
+++ b/src/hooks/useBusinessProfile.ts
@@ -37,11 +37,17 @@ export function useBusinessProfile() {
 
       if (error) throw error;
       setProfile(data);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching business profile:', error);
+      let description = 'Failed to fetch business profile';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to fetch business profile",
+        description,
         variant: "destructive",
       });
     } finally {
@@ -58,7 +64,7 @@ export function useBusinessProfile() {
 
       if (error) throw error;
       setIndustries(data || []);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching industries:', error);
     }
   };
@@ -72,7 +78,7 @@ export function useBusinessProfile() {
 
       if (error) throw error;
       setDepartments(data || []);
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching departments:', error);
     }
   };
@@ -99,11 +105,17 @@ export function useBusinessProfile() {
         description: "Business profile created successfully",
       });
       return data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating business profile:', error);
+      let description = 'Failed to create business profile';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to create business profile",
+        description,
         variant: "destructive",
       });
       throw error;
@@ -132,11 +144,17 @@ export function useBusinessProfile() {
         description: "Business profile updated successfully",
       });
       return data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error updating business profile:', error);
+      let description = 'Failed to update business profile';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to update business profile",
+        description,
         variant: "destructive",
       });
       throw error;

--- a/src/hooks/usePosts.ts
+++ b/src/hooks/usePosts.ts
@@ -60,12 +60,18 @@ export function usePosts() {
 
       if (error) throw error;
       setPosts((data as Post[]) || []);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching posts:', err);
-      setError(err.message || 'Failed to fetch posts');
+      const message =
+        err instanceof Error
+          ? err.message
+          : err && typeof err === 'object' && 'message' in err && typeof (err as { message?: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : 'Failed to fetch posts';
+      setError(message);
       toast({
         title: "Error",
-        description: "Failed to fetch posts",
+        description: message,
         variant: "destructive",
       });
     } finally {
@@ -129,11 +135,17 @@ export function usePosts() {
       });
       
       return data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating post:', error);
+      let description = 'Failed to create post';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to create post",
+        description,
         variant: "destructive",
       });
       throw error;
@@ -159,7 +171,7 @@ export function usePosts() {
           relation_type: relation.relation_type,
         });
       if (error) throw error;
-    } catch (error) {
+    } catch (error: unknown) {
       console.error('Error creating post relation:', error);
       toast({
         title: 'Relation not linked',
@@ -197,11 +209,17 @@ export function usePosts() {
       });
       
       return data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error updating post:', error);
+      let description = 'Failed to update post';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to update post",
+        description,
         variant: "destructive",
       });
       throw error;
@@ -232,11 +250,17 @@ export function usePosts() {
       });
       
       return true;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error deleting post:', error);
+      let description = 'Failed to delete post';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to delete post",
+        description,
         variant: "destructive",
       });
       return false;
@@ -258,9 +282,15 @@ export function usePosts() {
 
       if (error) throw error;
       return data as Post;
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching post:', err);
-      setError(err.message || 'Failed to fetch post');
+      const message =
+        err instanceof Error
+          ? err.message
+          : err && typeof err === 'object' && 'message' in err && typeof (err as { message?: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : 'Failed to fetch post';
+      setError(message);
       throw err;
     } finally {
       setLoading(false);
@@ -280,7 +310,7 @@ export function usePosts() {
 
       if (error) throw error;
       return relations || [];
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching post relations:', err);
       return [];
     }
@@ -301,12 +331,18 @@ export function usePosts() {
 
       if (error) throw error;
       setPosts((data as Post[]) || []);
-    } catch (err: any) {
+    } catch (err: unknown) {
       console.error('Error fetching user posts:', err);
-      setError(err.message || 'Failed to fetch your posts');
+      const message =
+        err instanceof Error
+          ? err.message
+          : err && typeof err === 'object' && 'message' in err && typeof (err as { message?: unknown }).message === 'string'
+            ? (err as { message: string }).message
+            : 'Failed to fetch your posts';
+      setError(message);
       toast({
         title: "Error",
-        description: "Failed to fetch your posts",
+        description: message,
         variant: "destructive",
       });
     } finally {

--- a/src/pages/Admin.tsx
+++ b/src/pages/Admin.tsx
@@ -36,10 +36,17 @@ export function Admin() {
 
       if (error) throw error;
       setIdeas(data || []);
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to fetch ideas', error);
+      let description = 'Failed to fetch ideas.';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to fetch ideas.",
+        description,
         variant: "destructive",
       });
     } finally {
@@ -66,10 +73,17 @@ export function Admin() {
         title: "Success",
         description: `Idea ${!currentStatus ? "added to" : "removed from"} curated feed.`,
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to update idea', error);
+      let description = 'Failed to update idea.';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: "Failed to update idea.",
+        description,
         variant: "destructive",
       });
     }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -70,8 +70,15 @@ export default function Auth() {
       }
       
       toast.success('Account created! Check your email to verify.');
-    } catch (error: any) {
-      toast.error(error.message || 'Failed to create account');
+    } catch (error: unknown) {
+      console.error('Failed to create account', error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string'
+            ? (error as { message: string }).message
+            : 'Failed to create account';
+      toast.error(message);
     } finally {
       setLoading(false);
     }

--- a/src/pages/CreateBusiness.tsx
+++ b/src/pages/CreateBusiness.tsx
@@ -87,11 +87,17 @@ export function CreateBusiness() {
       });
 
       navigate('/business-profile');
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error creating business:', error);
+      let description = 'Failed to create business';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to create business",
+        description,
         variant: "destructive",
       });
     } finally {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -52,10 +52,17 @@ export default function Settings() {
         title: "Account Deletion Request",
         description: "Your account deletion request has been submitted. We'll process it within 24 hours.",
       });
-    } catch (error: any) {
+    } catch (error: unknown) {
+      console.error('Failed to process account deletion', error);
+      let description = 'Failed to process account deletion';
+      if (error instanceof Error) {
+        description = error.message;
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message?: unknown }).message === 'string') {
+        description = (error as { message: string }).message;
+      }
       toast({
         title: "Error",
-        description: error.message || "Failed to process account deletion",
+        description,
         variant: "destructive",
       });
     } finally {


### PR DESCRIPTION
## Summary
- update various components, hooks, and pages to catch unknown errors and log the original issue for debugging
- derive user-facing messages safely from Error instances or structured Supabase errors with sensible fallbacks
- ensure toasts and state updates use the refined error messaging across profile, invitation, post, and idea flows

## Testing
- npm run lint *(fails: existing lint violations unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbe63ed1c83209dbf99063c3a4847