### PR TITLE
Adjust RightSidebar gating logic

### DIFF
--- a/src/components/layout/RightSidebar.tsx
+++ b/src/components/layout/RightSidebar.tsx
@@ -8,7 +8,7 @@ import { FeedsAdapter, type FeedItem, type HistoryItem } from '@/adapters/feedsA
 import { SHOW_RIGHT_SIDEBAR } from '@/config/flags';
 
 export function RightSidebar() {
-  if (!SHOW_RIGHT_SIDEBAR) return null;
+  const showSidebar = SHOW_RIGHT_SIDEBAR;
 
   const adapter = useMemo(() => new FeedsAdapter(), []);
   const [ideas, setIdeas] = useState<FeedItem[]>([]);
@@ -18,6 +18,10 @@ export function RightSidebar() {
   const [visible, setVisible] = useState({ ideas: 12 });
 
   useEffect(() => {
+    if (!showSidebar) {
+      return;
+    }
+
     (async () => {
       try {
         const list = await adapter.getOpenIdeasFeed();      // uses existing adapter
@@ -39,10 +43,12 @@ export function RightSidebar() {
         setLoadingHist(false);
       }
     })();
-  }, [adapter]);
+  }, [adapter, showSidebar]);
 
   const loadMoreIdeas = () =>
     setVisible(v => ({ ...v, ideas: Math.min(v.ideas + 12, ideas.length) }));
+
+  if (!showSidebar) return null;
 
   return (
     <aside className="right-sidebar-overlay glass-card p-3"


### PR DESCRIPTION
## Summary
- move the sidebar flag into a dedicated constant so hooks always run in the same order
- short-circuit data loading and rendering when the sidebar is disabled

## Testing
- npm run lint *(fails: existing lint violations across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbe50595c83209550c1ca5547992e