### PR TITLE
Expose analytics session ID getter

### DIFF
--- a/src/components/landing/ComposerSection.tsx
+++ b/src/components/landing/ComposerSection.tsx
@@ -111,7 +111,7 @@ export function ComposerSection({ isVisible }: ComposerSectionProps) {
           email: email || null,
           notify_on_interaction: notifyInteraction,
           subscribe_newsletter: subscribeNews,
-          session_id: (analytics as any).sessionId
+          session_id: analytics.getSessionId()
         }
       });
 
@@ -127,11 +127,14 @@ export function ComposerSection({ isVisible }: ComposerSectionProps) {
         throw new Error(data?.error || 'Unknown error');
       }
 
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error submitting idea:', error);
+      const errorMessage = error instanceof Error
+        ? error.message
+        : 'Failed to submit idea. Please try again.';
       toast({
         title: 'Error',
-        description: error.message || 'Failed to submit idea. Please try again.',
+        description: errorMessage,
         variant: 'destructive',
       });
     } finally {

--- a/src/hooks/useAnalytics.ts
+++ b/src/hooks/useAnalytics.ts
@@ -15,6 +15,10 @@ class AnalyticsService {
     sessionStorage.setItem('analytics_session_id', this.sessionId);
   }
 
+  getSessionId(): string {
+    return this.sessionId;
+  }
+
   private generateSessionId(): string {
     return Date.now().toString(36) + Math.random().toString(36).substr(2);
   }


### PR DESCRIPTION
## Summary
- expose the analytics service session id through a public getter
- replace composer submission's direct property access with the new getter
- improve composer submission error handling when the caught value is not an Error instance

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbe4819e48320ab1fe4bdf333fbdd