### PR TITLE
Type brainstorm preview selections

### DIFF
--- a/src/components/BrainstormPreviewList.tsx
+++ b/src/components/BrainstormPreviewList.tsx
@@ -1,19 +1,19 @@
 import { useState, useEffect } from "react";
 import { BrainstormCard } from "@/components/BrainstormCard";
 import { BrainstormModal } from "@/components/BrainstormModal";
-import { useFreeBrainstorms } from "@/hooks/useOpenIdeas";
+import { useFreeBrainstorms, IdeaBrainstorm } from "@/hooks/useOpenIdeas";
 import { useAnalytics } from "@/hooks/useAnalytics";
 import { Lightbulb } from "lucide-react";
 
 export function BrainstormPreviewList() {
   const { data: freeBrainstorms = [] } = useFreeBrainstorms();
-  const [selectedBrainstorm, setSelectedBrainstorm] = useState(null);
+  const [selectedBrainstorm, setSelectedBrainstorm] = useState<IdeaBrainstorm | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const analytics = useAnalytics();
 
   const limitedBrainstorms = freeBrainstorms.slice(0, 3);
 
-  const handleCardClick = (brainstorm: any) => {
+  const handleCardClick = (brainstorm: IdeaBrainstorm) => {
     analytics.trackTeaserClick(brainstorm.id);
     setSelectedBrainstorm(brainstorm);
     setIsModalOpen(true);

--- a/src/components/landing/FeaturedBranches.tsx
+++ b/src/components/landing/FeaturedBranches.tsx
@@ -1,21 +1,27 @@
 import { useState } from 'react';
-import { useFreeBrainstorms } from '@/hooks/useOpenIdeas';
+import { useFreeBrainstorms, IdeaBrainstorm } from '@/hooks/useOpenIdeas';
 import { BrainstormCard } from '@/components/BrainstormCard';
 import { BrainstormModal } from '@/components/BrainstormModal';
 import { MessageSquare, TrendingUp, Lightbulb } from 'lucide-react';
 
+function hasGtag(
+  win: Window & typeof globalThis,
+): win is Window & typeof globalThis & { gtag: (...args: unknown[]) => void } {
+  return 'gtag' in win && typeof win.gtag === 'function';
+}
+
 export function FeaturedBranches() {
   const { data: freeBrainstorms = [], isLoading } = useFreeBrainstorms();
-  const [selectedBrainstorm, setSelectedBrainstorm] = useState(null);
+  const [selectedBrainstorm, setSelectedBrainstorm] = useState<IdeaBrainstorm | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  const handleCardClick = (brainstorm: any) => {
+  const handleCardClick = (brainstorm: IdeaBrainstorm) => {
     setSelectedBrainstorm(brainstorm);
     setIsModalOpen(true);
 
     // Analytics event
-    if (typeof window !== 'undefined' && (window as any).gtag) {
-      (window as any).gtag('event', 'teaser_click', {
+    if (typeof window !== 'undefined' && hasGtag(window)) {
+      window.gtag('event', 'teaser_click', {
         event_category: 'engagement',
         event_label: brainstorm.id,
       });


### PR DESCRIPTION
## Summary
- add IdeaBrainstorm typing to brainstorm preview and landing components
- ensure BrainstormModal consumers pass typed brainstorm values
- guard analytics tracking with a runtime check for gtag

## Testing
- npm run lint *(fails: pre-existing lint violations across project)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbe2d1a948320873a5c41bb5b5c0f