### PR TITLE
Adjust business mode color tokens

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -111,4 +111,28 @@
     --glass-bg: 222 84% 5% / 0.8;
     --glass-border: 210 40% 98% / 0.1;
   }
+
+  body[data-mode="business"],
+  body[data-bg="dark"] {
+    --background: 222 72% 11%;
+    --foreground: var(--text-ink-d);
+    --card: 223 64% 15%;
+    --card-foreground: var(--text-ink-d);
+    --popover: 223 64% 15%;
+    --popover-foreground: var(--text-ink-d);
+    --secondary: 222 54% 22%;
+    --secondary-foreground: var(--text-ink-d);
+    --muted: 221 48% 20%;
+    --muted-foreground: 210 38% 82%;
+    --accent: 222 58% 24%;
+    --accent-foreground: var(--text-ink-d);
+    --destructive: 0 70% 52%;
+    --destructive-foreground: var(--text-ink-d);
+    --border: 220 46% 40%;
+    --input: 220 48% 32%;
+    --ring: 212 72% 60%;
+    --text-ink: var(--text-ink-d);
+    --glass-bg: hsl(222 84% 5% / 0.78);
+    --glass-border: hsl(210 40% 98% / 0.12);
+  }
 }


### PR DESCRIPTION
## Summary
- add a business-mode override in `src/index.css` so foreground tokens switch to light ink on dark canvases
- tune the paired background, card, muted, and accent tokens for the navy gradient experience so translucency utilities stay legible

## Testing
- `npm run lint` *(fails: existing lint debt across unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccbd4be64483209332a6c71487f1ca