### PR TITLE
Memoize business hooks fetch callbacks

### DIFF
--- a/src/hooks/useBusinessInvitations.ts
+++ b/src/hooks/useBusinessInvitations.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useAuth } from '@/contexts/AuthContext';
 import { useToast } from '@/hooks/use-toast';
@@ -34,7 +34,7 @@ export function useBusinessInvitations() {
   const [invitations, setInvitations] = useState<BusinessInvitation[]>([]);
   const [receivedInvitations, setReceivedInvitations] = useState<BusinessInvitation[]>([]);
 
-  const fetchSentInvitations = async () => {
+  const fetchSentInvitations = useCallback(async () => {
     if (!user) return;
     setLoading(true);
     try {
@@ -57,9 +57,9 @@ export function useBusinessInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
 
-  const fetchReceivedInvitations = async () => {
+  const fetchReceivedInvitations = useCallback(async () => {
     if (!user) return;
     setLoading(true);
     try {
@@ -88,10 +88,10 @@ export function useBusinessInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
 
   // CREATE via RPC (server-side token + RLS)
-  const createInvitation = async (input: CreateInvitationData) => {
+  const createInvitation = useCallback(async (input: CreateInvitationData) => {
     if (!user) {
       toast({
         title: 'Authentication Required',
@@ -129,10 +129,10 @@ export function useBusinessInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast, fetchSentInvitations]);
 
   // ACCEPT via RPC (needs the token)
-  const acceptInvitation = async (token: string) => {
+  const acceptInvitation = useCallback(async (token: string) => {
     if (!user) return false;
     setLoading(true);
     try {
@@ -160,10 +160,10 @@ export function useBusinessInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast, fetchSentInvitations]);
 
   // REJECT by marking consumed (allowed by RLS policy "Invitee can mark consumed")
-  const rejectInvitation = async (id: string) => {
+  const rejectInvitation = useCallback(async (id: string) => {
     if (!user) return false;
     setLoading(true);
     try {
@@ -198,19 +198,22 @@ export function useBusinessInvitations() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
 
   // Token processing now only occurs on /accept-invite page
 
   // Expose a convenience status helper if you want it in the UI
-  const getInvitationStatus = (inv: BusinessInvitation) => computeStatus(inv);
+  const getInvitationStatus = useCallback(
+    (inv: BusinessInvitation) => computeStatus(inv),
+    [],
+  );
 
   useEffect(() => {
     if (user) {
       fetchSentInvitations();
       fetchReceivedInvitations();
     }
-  }, [user]);
+  }, [user, fetchSentInvitations, fetchReceivedInvitations]);
 
   return {
     invitations,

--- a/src/hooks/useBusinessProfile.ts
+++ b/src/hooks/useBusinessProfile.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { BusinessProfile, Industry, Department } from '@/types/database';
 import { useAuth } from '@/contexts/AuthContext';
@@ -12,17 +12,9 @@ export function useBusinessProfile() {
   const [industries, setIndustries] = useState<Industry[]>([]);
   const [departments, setDepartments] = useState<Department[]>([]);
 
-  useEffect(() => {
-    if (user) {
-      fetchProfile();
-      fetchIndustries();
-      fetchDepartments();
-    }
-  }, [user]);
-
-  const fetchProfile = async () => {
+  const fetchProfile = useCallback(async () => {
     if (!user) return;
-    
+
     setLoading(true);
     try {
       const { data, error } = await supabase
@@ -47,9 +39,9 @@ export function useBusinessProfile() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user, toast]);
 
-  const fetchIndustries = async () => {
+  const fetchIndustries = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('industries')
@@ -61,9 +53,9 @@ export function useBusinessProfile() {
     } catch (error: any) {
       console.error('Error fetching industries:', error);
     }
-  };
+  }, []);
 
-  const fetchDepartments = async () => {
+  const fetchDepartments = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('departments')
@@ -75,7 +67,15 @@ export function useBusinessProfile() {
     } catch (error: any) {
       console.error('Error fetching departments:', error);
     }
-  };
+  }, []);
+
+  useEffect(() => {
+    if (user) {
+      fetchProfile();
+      fetchIndustries();
+      fetchDepartments();
+    }
+  }, [user, fetchProfile, fetchIndustries, fetchDepartments]);
 
   const createProfile = async (profileData: any) => {
     if (!user) return;

--- a/src/hooks/useUserRoles.ts
+++ b/src/hooks/useUserRoles.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/contexts/AuthContext';
 import { supabase } from '@/integrations/supabase/client';
 
@@ -7,7 +7,7 @@ export function useUserRoles() {
   const [roles, setRoles] = useState<string[]>([]);
   const [loading, setLoading] = useState(true);
 
-  const fetchRoles = async () => {
+  const fetchRoles = useCallback(async () => {
     if (!user) {
       setRoles([]);
       setLoading(false);
@@ -30,11 +30,11 @@ export function useUserRoles() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [user]);
 
   useEffect(() => {
     fetchRoles();
-  }, [user]);
+  }, [fetchRoles]);
 
   const hasRole = (role: string) => roles.includes(role);
   const hasAnyRole = (roleList: string[]) => roleList.some(role => roles.includes(role));
@@ -51,10 +51,7 @@ export function useUserRoles() {
     // Backward compatibility
     userRoles: roles,
     refetch: () => {
-      // Re-trigger the effect by updating user dependency
-      if (user) {
-        fetchRoles();
-      }
+      fetchRoles();
     },
   };
 }


### PR DESCRIPTION
## Summary
- wrap business invitation fetch helpers (and related actions) with useCallback and update effect dependencies
- memoize business profile data fetch helpers and include callbacks in hook effects
- memoize user roles fetch function and reuse the callback inside effects and refetch helpers

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb48ff2ac8320add59c75c3e4379c